### PR TITLE
feat(utils): add parallelApN function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -144,6 +144,20 @@ module.exports = ({ $: { Any, AnyFunction, Array, Boolean, create, env, Function
   ([AnyFunction, AnyFunction, Any, Array(Any)])
   (parallelApImpl);
 
+  const parallelApNImpl = (functions) => (x) => functions.reduce((acc, fn) => [...acc, fn(x)], []);
+
+  /**
+   parallelApN :: Array Function => Any a => Array(a)
+   *
+   * Takes N functions and applies them to the same given value, returning an array of results
+   *
+   * @returns {Array}
+   */
+  const parallelApN = def('parallelApN')
+  ({})
+  ([Array(AnyFunction), Any, Array(Any)])
+  (parallelApNImpl);
+
   const includesImpl = (value) => (list) => list.includes(value);
   /**
    includes :: Any => Array Any => Boolean
@@ -204,6 +218,6 @@ module.exports = ({ $: { Any, AnyFunction, Array, Boolean, create, env, Function
   ([Function([Any, Boolean]), String, Array(Object), Array(Maybe(Any))])
   (pluckImpl)
 
-  return { allPass, anyPass, F, map2, map3, noop, parallelAp, pReject, pResolve, T, tap, zipObj, includes, included: C(includes), getEq, findEq, pluck };
+  return { allPass, anyPass, F, map2, map3, noop, parallelAp, parallelApN, pReject, pResolve, T, tap, zipObj, includes, included: C(includes), getEq, findEq, pluck };
 }
 

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -6,7 +6,7 @@ const { describe, expect, it } = require('@jest/globals');
 const {
   sanctuary: { add, compose: B, equals, fromMaybe, gt, is, Just, Nothing, pipe, size, splitOn }
   , sanctuaryDef: { Array, Number, String }
-  , utils: { allPass, anyPass, F, findEq, getEq, included, includes, map2, map3, noop, parallelAp, pluck, pReject, pResolve, T, tap, zipObj }
+  , utils: { allPass, anyPass, F, findEq, getEq, included, includes, map2, map3, noop, parallelAp, parallelApN, pluck, pReject, pResolve, T, tap, zipObj }
 } = require('.');
 
 const getStringLength = B(size)(splitOn(''));
@@ -107,6 +107,12 @@ describe('utils tests', () => {
 
     it('fails due to one of the functions is not a function', () =>
       expect(() => parallelAp('Not a function')(add(2))(1)).toThrowError(/The value at position 1 is not a member of ‘Function’/));
+
+    it('it parallel applies N functions to same value', () =>
+      expect(parallelApN([add(1), add(2)])(1)).toStrictEqual([2, 3]));
+
+    it('fails due to one of the functions is not a function', () =>
+      expect(() => parallelApN(['Not a function', add(2)])(1)).toThrowError(/The value at position 1 is not a member of ‘Function’/));
   });
 
   describe('getEq tests', () => {


### PR DESCRIPTION
Consider to add this function as an "improve" to your `parallelAp` that takes 2 curried functions instead of an array of N functions to apply over a given entry.